### PR TITLE
fixed filepath check for continued download to match write directory …

### DIFF
--- a/src/getaudio.py
+++ b/src/getaudio.py
@@ -41,7 +41,7 @@ class GetAudio:
         counter = 0
 
         for lang_num in self.audio_df['language_num']:
-            if not os.path.exists(self.destination_folder +'{}.wav'.format(lang_num)):
+            if not os.path.exists('../' + self.destination_folder +'{}.wav'.format(lang_num)):
                 if self.debug:
                     print('downloading {}'.format(lang_num))
                 (filename, headers) = urllib.request.urlretrieve(self.url.format(lang_num))


### PR DESCRIPTION
Thanks for the work!

It looks like there is a small issue with continued file writes (such as the case where the downloads timeout and you need to resume).  The directory check is for audio/ but the write is for ../audio
